### PR TITLE
Add metaprogramming and multithreading utilities

### DIFF
--- a/include/orizzonte/meta.hpp
+++ b/include/orizzonte/meta.hpp
@@ -4,5 +4,7 @@
 
 #pragma once
 
-#include "./orizzonte/meta.hpp"
-#include "./orizzonte/utility.hpp"
+#include "./meta/constant.hpp"
+#include "./meta/enumerate_args.hpp"
+#include "./meta/sequence.hpp"
+#include "./meta/type_wrapper.hpp"

--- a/include/orizzonte/meta/constant.hpp
+++ b/include/orizzonte/meta/constant.hpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2017 Vittorio Romeo
+// MIT License |  https://opensource.org/licenses/MIT
+// http://vittorioromeo.info | vittorio.romeo@outlook.com
+
+#pragma once
+
+#include <utility>
+
+namespace orizzonte::meta
+{
+    /// @brief Alias for `std::integral_constant` that deduces the constant type.
+    template <auto X>
+    using constant_t = std::integral_constant<decltype(X), X>;
+
+    /// @brief `constexpr` variable template for `constant_t`.
+    template <auto X>
+    inline constexpr constant_t<X> constant_v{};
+
+    /// @copydoc constant_v
+    template <auto X>
+    inline constexpr constant_t<X> c{};
+}

--- a/include/orizzonte/meta/enumerate_args.hpp
+++ b/include/orizzonte/meta/enumerate_args.hpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2017 Vittorio Romeo
+// MIT License |  https://opensource.org/licenses/MIT
+// http://vittorioromeo.info | vittorio.romeo@outlook.com
+
+#pragma once
+
+#include "../utility/fwd.hpp"
+#include "./constant.hpp"
+#include "./sequence.hpp"
+
+namespace orizzonte::meta
+{
+    namespace detail
+    {
+        template <typename F, typename... Ts, auto... Is>
+        void enumerate_args_impl(std::index_sequence<Is...>, F&& f, Ts&&... xs)
+        {
+            // `std::index_sequence` is used instead of `sequence_t` as
+            // `sequence_for_v<>` is a `std::size_t` sequence.
+            (f(c<Is>, FWD(xs)), ...);
+        }
+    }
+
+    /// @brief Inkoves `f(i, x)` for every element in `xs...`, where `i` is a
+    /// compile-time integer of the current "iteration" and `x` is the `i`-th
+    /// element of `xs...`.
+    template <typename F, typename... Ts>
+    void enumerate_args(F&& f, Ts&&... xs)
+    {
+        detail::enumerate_args_impl(sequence_for_v<Ts...>, FWD(f), FWD(xs)...);
+    }
+}

--- a/include/orizzonte/meta/sequence.hpp
+++ b/include/orizzonte/meta/sequence.hpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2017 Vittorio Romeo
+// MIT License |  https://opensource.org/licenses/MIT
+// http://vittorioromeo.info | vittorio.romeo@outlook.com
+
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+namespace orizzonte::meta
+{
+    namespace detail
+    {
+        template <auto... Is>
+        struct seq_type : std::common_type<decltype(Is)...>
+        {
+        };
+
+        template <>
+        struct seq_type<>
+        {
+            using type = int;
+        };
+    }
+
+    /// @brief Alias for `std::integer_sequence` that deduces the constant type.
+    /// If the sequence is empty, `int` is deduced.
+    template <auto... Is>
+    using sequence_t =
+        std::integer_sequence<typename detail::seq_type<Is...>::type, Is...>;
+
+    /// @brief `constexpr` variable template for `sequence_t`.
+    template <auto... Is>
+    inline constexpr sequence_t<Is...> sequence_v{};
+
+    /// @brief `constexpr` variable template for `std::index_sequence_for`.
+    template <typename... Ts>
+    inline constexpr std::index_sequence_for<Ts...> sequence_for_v{};
+}

--- a/include/orizzonte/meta/type_wrapper.hpp
+++ b/include/orizzonte/meta/type_wrapper.hpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2017 Vittorio Romeo
+// MIT License |  https://opensource.org/licenses/MIT
+// http://vittorioromeo.info | vittorio.romeo@outlook.com
+
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+namespace orizzonte::meta
+{
+    /// @brief Empty class that "stores" the type `T`.
+    template <typename T>
+    struct type_wrapper
+    {
+        using type = T;
+    };
+
+    /// @brief `constexpr` variable template for `type_wrapper`.
+    template <typename T>
+    inline constexpr type_wrapper<T> t{};
+
+    /// @brief Extracts the type "stored" into a `type_wrapper` instance.
+    template <typename T>
+    using unwrap = typename T::type;
+}

--- a/include/orizzonte/utility.hpp
+++ b/include/orizzonte/utility.hpp
@@ -4,5 +4,8 @@
 
 #pragma once
 
+#include "./utility/aligned_storage.hpp"
+#include "./utility/bool_latch.hpp"
 #include "./utility/fwd.hpp"
+#include "./utility/movable_atomic.hpp"
 #include "./utility/nothing.hpp"

--- a/include/orizzonte/utility/aligned_storage.hpp
+++ b/include/orizzonte/utility/aligned_storage.hpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2017 Vittorio Romeo
+// MIT License |  https://opensource.org/licenses/MIT
+// http://vittorioromeo.info | vittorio.romeo@outlook.com
+
+#pragma once
+
+#include <cassert>
+#include <type_traits>
+#include <utility>
+
+namespace orizzonte::utility
+{
+    /// @brief Provides aligned storage for a `T` instance and utilities to
+    /// construct/destroy/access the stored `T`.
+    template <typename T>
+    class aligned_storage_for
+    {
+    private:
+        std::aligned_storage_t<sizeof(T), alignof(T)> _storage;
+
+        // TODO: more portable
+#ifndef NDEBUG
+        bool _engaged{false};
+
+        // clang-format off
+        void set_engaged() noexcept      { _engaged = true; }
+        void set_unengaged() noexcept    { _engaged = false; }
+        void assert_engaged() noexcept   { assert(_engaged); }
+        void assert_unengaged() noexcept { assert(!_engaged); }
+        // clang-format on
+#else
+        // clang-format off
+        constexpr void set_engaged() noexcept      { }
+        constexpr void set_unengaged() noexcept    { }
+        constexpr void assert_engaged() noexcept   { }
+        constexpr void assert_unengaged() noexcept { }
+        // clang-format on
+#endif
+
+    public:
+        /// @brief Constructs a new instance of `T` in the storage using
+        /// perfect-forwarding and placement-new. The behavior is undefined if a
+        /// `T` instance was already constructed beforehand and not destroyed.
+        template <typename TFwd>
+        void construct(TFwd&& x)
+        {
+            assert_unengaged();
+            new(&_storage) std::decay_t<TFwd>(FWD(x));
+            set_engaged();
+        }
+
+        /// @brief Returns a reference to the stored `T`. The behavior is
+        /// undefined if a `T` instance wasn't successfully constructed
+        /// beforehand.
+        T& access() noexcept
+        {
+            assert_engaged();
+            return reinterpret_cast<T&>(_storage);
+        }
+
+        /// @copydoc access
+        const T& access() const noexcept
+        {
+            assert_engaged();
+            return reinterpret_cast<T&>(_storage);
+        }
+
+        /// @brief Invokes the destructor of the currently stored `T`. The
+        /// behavior is undefined if a `T` instance wasn't successfully
+        /// constructed beforehand.
+        void destroy()
+        {
+            assert_engaged();
+            access().~T();
+            set_unengaged();
+        }
+    };
+}

--- a/include/orizzonte/utility/bool_latch.hpp
+++ b/include/orizzonte/utility/bool_latch.hpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2017 Vittorio Romeo
+// MIT License |  https://opensource.org/licenses/MIT
+// http://vittorioromeo.info | vittorio.romeo@outlook.com
+
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+
+namespace orizzonte::utility
+{
+    /// @brief Binary latch that can block the current thread until
+    /// `count_down()` is invoked.
+    class bool_latch
+    {
+    private:
+        std::condition_variable _cv;
+        std::mutex _mtx;
+        bool _finished{false};
+
+    public:
+        void count_down()
+        {
+            std::scoped_lock lk{_mtx};
+            _finished = true;
+            _cv.notify_all();
+        }
+
+        void wait()
+        {
+            std::unique_lock lk{_mtx};
+            _cv.wait(lk, [this] { return _finished; });
+        }
+    };
+
+    /// @brief Wrapper around `bool_latch` that automatically invokes `wait()`
+    /// on destruction.
+    class scoped_bool_latch : bool_latch
+    {
+    public:
+        scoped_bool_latch() = default;
+
+        // Prevent copies.
+        scoped_bool_latch(const scoped_bool_latch&) = delete;
+        scoped_bool_latch& operator=(const scoped_bool_latch&) = delete;
+
+        // Prevent moves.
+        scoped_bool_latch(scoped_bool_latch&&) = delete;
+        scoped_bool_latch& operator=(scoped_bool_latch&&) = delete;
+
+        ~scoped_bool_latch()
+        {
+            this->wait();
+        }
+
+        using bool_latch::count_down;
+    };
+}

--- a/include/orizzonte/utility/movable_atomic.hpp
+++ b/include/orizzonte/utility/movable_atomic.hpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2017 Vittorio Romeo
+// MIT License |  https://opensource.org/licenses/MIT
+// http://vittorioromeo.info | vittorio.romeo@outlook.com
+
+#pragma once
+
+#include <atomic>
+
+namespace orizzonte::utility
+{
+    /// @brief Wrapper around `std::atomic` that allows move operations.
+    /// @details Moves are implemented as `store(load())`.
+    template <typename T>
+    struct movable_atomic : std::atomic<T>
+    {
+        using std::atomic<T>::atomic;
+
+        movable_atomic(movable_atomic&& rhs) : std::atomic<T>{rhs.load()}
+        {
+        }
+
+        movable_atomic& operator=(movable_atomic&& rhs)
+        {
+            this->store(rhs.load());
+            return *this;
+        }
+    };
+}

--- a/include/orizzonte/utility/nothing.hpp
+++ b/include/orizzonte/utility/nothing.hpp
@@ -115,7 +115,7 @@ namespace orizzonte::utility
         {
         }
 
-        // clang-format off
+// clang-format off
         #define CALL_OPERATOR(ref_qual)                                                       \
         template <typename... Ts>                                                             \
         constexpr auto operator()(Ts&&... xs) ref_qual                                        \

--- a/src/temp.cpp
+++ b/src/temp.cpp
@@ -2,67 +2,22 @@
 // MIT License |  https://opensource.org/licenses/MIT
 // http://vittorioromeo.info | vittorio.romeo@outlook.com
 
-#include <type_traits>
-#include <memory>
-#include <utility>
+#include <atomic>
 #include <cassert>
+#include <chrono>
+#include <condition_variable>
 #include <future>
 #include <iostream>
-#include <condition_variable>
+#include <memory>
 #include <mutex>
-#include <atomic>
 #include <random>
-#include <chrono>
+#include <type_traits>
+#include <utility>
 
 #include "../include/orizzonte.hpp"
 
 using namespace orizzonte::utility;
-
-template <typename F, typename... Ts, std::size_t... Is>
-void enumerate_args_impl(std::index_sequence<Is...>, F&& f, Ts&&... xs)
-{
-    (f(std::integral_constant<std::size_t, Is>{}, FWD(xs)), ...);
-}
-
-template <typename F, typename... Ts>
-void enumerate_args(F&& f, Ts&&... xs)
-{
-    enumerate_args_impl(std::index_sequence_for<Ts...>{}, FWD(f), FWD(xs)...);
-}
-
-template <typename T>
-struct type_wrapper
-{
-    using type = T;
-};
-
-template <typename T>
-inline constexpr type_wrapper<T> type_wrapper_v{};
-
-template <typename T>
-using unwrap_type = typename std::decay_t<T>::type;
-
-class bool_latch
-{
-private:
-    std::condition_variable _cv;
-    std::mutex _mtx;
-    bool _finished{false};
-
-public:
-    void count_down()
-    {
-        std::scoped_lock lk{_mtx};
-        _finished = true;
-        _cv.notify_all();
-    }
-
-    void wait()
-    {
-        std::unique_lock lk{_mtx};
-        _cv.wait(lk, [this]{ return _finished; });
-    }
-};
+using namespace orizzonte::meta;
 
 template <typename Parent, typename F>
 class node;
@@ -140,23 +95,24 @@ public:
     decltype(auto) wait_and_get(Scheduler&& s) &&
     {
         typename Derived::output_type out;
-        bool_latch l;
 
-        auto f = std::move(as_derived()).then([&](auto&&... x)
         {
-            ((out = FWD(x)), ...);
-            l.count_down();
-        });
+            orizzonte::utility::scoped_bool_latch l;
+            auto f = std::move(as_derived()).then([&](auto&&... x) {
+                ((out = FWD(x)), ...);
+                l.count_down();
+            });
 
-        f.walk_up(s);
+            f.walk_up(s);
+        }
 
-        l.wait();
         return out;
     }
 };
 
 template <typename Parent, typename F>
-class node : private child_of<Parent>, private F,
+class node : private child_of<Parent>,
+             private F,
              public node_base<node<Parent, F>>
 {
 public:
@@ -172,8 +128,8 @@ public:
     friend crtp_base_type;
 
     using crtp_base_type::then;
-    using crtp_base_type::walk_up;
     using crtp_base_type::wait_and_get;
+    using crtp_base_type::walk_up;
 
 private:
     auto& as_f() noexcept
@@ -188,55 +144,48 @@ public:
         call_ignoring_nothing(as_f(), FWD(r));
     }
 
-    template <typename Scheduler, typename Result, typename Child, typename... Children>
+    template <typename Scheduler, typename Result, typename Child,
+        typename... Children>
     void execute(Scheduler&& s, Result&& r, Child& c, Children&... cs) &
     {
         // `r` doesn't need to be stored inside the node here as it is used
         // to synchronously invoke `as_f()`.
         c.execute(s, call_ignoring_nothing(as_f(), FWD(r)), cs...);
     }
-
 };
 
 template <typename ParentFwd, typename FFwd>
-node(ParentFwd&&, FFwd&&) -> node<std::decay_t<ParentFwd>, std::decay_t<FFwd>>;
+node(ParentFwd&&, FFwd &&)->node<std::decay_t<ParentFwd>, std::decay_t<FFwd>>;
 
 template <typename Parent>
-class schedule : private child_of<Parent>,
-                 public node_base<schedule<Parent>>
+class schedule : private child_of<Parent>, public node_base<schedule<Parent>>
 {
 public:
     using typename child_of<Parent>::input_type;
     using output_type = nothing;
 
     template <typename ParentFwd>
-    schedule(ParentFwd&& p) : child_of<Parent>{FWD(p)} { }
+    schedule(ParentFwd&& p) : child_of<Parent>{FWD(p)}
+    {
+    }
 
     using crtp_base_type = node_base<schedule<Parent>>;
     friend crtp_base_type;
 
     using crtp_base_type::then;
-    using crtp_base_type::walk_up;
     using crtp_base_type::wait_and_get;
+    using crtp_base_type::walk_up;
 
-    template <typename Scheduler, typename Result, typename Child, typename... Children>
+    template <typename Scheduler, typename Result, typename Child,
+        typename... Children>
     void execute(Scheduler&& s, Result&&, Child& c, Children&... cs) &
     {
-        s([&]{ c.execute(s, nothing{}, cs...); });
+        s([&] { c.execute(s, nothing{}, cs...); });
     }
 };
 
 template <typename ParentFwd>
-schedule(ParentFwd&&) -> schedule<std::decay_t<ParentFwd>>;
-
-template <typename T>
-struct movable_atomic : std::atomic<T>
-{
-    using std::atomic<T>::atomic;
-    movable_atomic(movable_atomic&& rhs) : std::atomic<T>{rhs.load()}
-    {
-    }
-};
+schedule(ParentFwd &&)->schedule<std::decay_t<ParentFwd>>;
 
 template <typename T>
 struct tuple_of_nothing_to_empty;
@@ -263,36 +212,39 @@ struct adapt_tuple_of_nothing;
 template <typename... Ts>
 struct adapt_tuple_of_nothing<std::tuple<Ts...>>
 {
-    using type = decltype(
-        std::tuple_cat(std::declval<tuple_of_nothing_to_empty_t<std::tuple<Ts>>>()...)
-    );
+    using type = decltype(std::tuple_cat(
+        std::declval<tuple_of_nothing_to_empty_t<std::tuple<Ts>>>()...));
 };
 
 template <typename T>
 using adapt_tuple_of_nothing_t = typename adapt_tuple_of_nothing<T>::type;
 
 template <typename Parent, typename... Fs>
-class when_all : private child_of<Parent>, private Fs...,
+class when_all : private child_of<Parent>,
+                 private Fs...,
                  public node_base<when_all<Parent, Fs...>>
 {
 public:
     using typename child_of<Parent>::input_type;
-    using output_type = std::tuple<result_of_ignoring_nothing_t<Fs&, input_type&>...>;
+    using output_type =
+        std::tuple<result_of_ignoring_nothing_t<Fs&, input_type&>...>;
 
-    // TODO: should this be done, or should the tuple be applied to following node?
-    // using output_type = adapt_tuple_of_nothing_t<
+    // TODO: should this be done, or should the tuple be applied to following
+    // node? using output_type = adapt_tuple_of_nothing_t<
     //     std::tuple<result_of_ignoring_nothing_t<Fs&, input_type&>...>
     // >;
 
 private:
-    // TODO: the size of the entire computation might grow by a lot. Is it possible to reuse this space for multiple nodes?
+    // TODO: the size of the entire computation might grow by a lot. Is it
+    // possible to reuse this space for multiple nodes?
     movable_atomic<int> _left{sizeof...(Fs)};
     output_type _out;
-    std::aligned_storage_t<sizeof(input_type), alignof(input_type)> _input_buf;
+    aligned_storage_for<input_type> _input_buf;
 
 public:
     template <typename ParentFwd, typename... FFwds>
-    when_all(ParentFwd&& p, FFwds&&... fs) : child_of<Parent>{FWD(p)}, Fs{FWD(fs)}...
+    when_all(ParentFwd&& p, FFwds&&... fs)
+        : child_of<Parent>{FWD(p)}, Fs{FWD(fs)}...
     {
     }
 
@@ -300,82 +252,91 @@ public:
     friend crtp_base_type;
 
     using crtp_base_type::then;
-    using crtp_base_type::walk_up;
     using crtp_base_type::wait_and_get;
+    using crtp_base_type::walk_up;
 
 public:
     template <typename Scheduler, typename Result>
     void execute(Scheduler&& s, Result&& r) &
     {
         // TODO: what if `Result` is an lvalue reference?
-        new (&_input_buf) std::decay_t<Result>(FWD(r));
+        _input_buf.construct(FWD(r));
 
-        enumerate_args([&](auto i, auto t)
-        {
-            auto do_computation = [&]
-            {
-                call_ignoring_nothing(static_cast<unwrap_type<decltype(t)>&>(*this),
-                                      reinterpret_cast<Result&>(_input_buf));
+        enumerate_args(
+            [&](auto i, auto t) {
+                auto do_computation = [&] {
+                    call_ignoring_nothing(
+                        static_cast<unwrap<decltype(t)>&>(*this),
+                        _input_buf.access());
 
-                if(_left.fetch_sub(1) == 1)
+                    if(_left.fetch_sub(1) == 1)
+                    {
+                        // TODO: make sure this destruction is correct, probably
+                        // should not destroy if storing lvalue reference
+                        _input_buf.destroy();
+                    }
+                };
+
+                if constexpr(i == sizeof...(Fs) - 1)
                 {
-                    // TODO: make sure this destruction is correct, probably should not destroy if storing lvalue reference
-                    reinterpret_cast<input_type&>(_input_buf).~input_type();
+                    do_computation();
                 }
-            };
-
-            if constexpr(i == sizeof...(Fs) - 1)
-            {
-                do_computation();
-            }
-            else
-            {
-                // `do_computation` has to be moved here as it will die at the end of the `enumerate_args` lambda scope.
-                s([g = std::move(do_computation)]{ g(); });
-            }
-        }, type_wrapper_v<Fs>...);
+                else
+                {
+                    // `do_computation` has to be moved here as it will die at
+                    // the end of the `enumerate_args` lambda scope.
+                    s([g = std::move(do_computation)] { g(); });
+                }
+            },
+            t<Fs>...);
     }
 
-    template <typename Scheduler, typename Result, typename Child, typename... Children>
+    template <typename Scheduler, typename Result, typename Child,
+        typename... Children>
     void execute(Scheduler&& s, Result&& r, Child& c, Children&... cs) &
     {
-        // This is necessary as `r` only lives as long as `execute` is active on the call stack.
-        // Computations might still be active when `execute` ends, even if the last one is executed on the same thread.
-        // This is because the scheduled computations might finish after the last one.
+        // This is necessary as `r` only lives as long as `execute` is active on
+        // the call stack. Computations might still be active when `execute`
+        // ends, even if the last one is executed on the same thread. This is
+        // because the scheduled computations might finish after the last one.
         // TODO: what if `Result` is an lvalue reference?
-        new (&_input_buf) std::decay_t<Result>(FWD(r));
+        _input_buf.construct(FWD(r));
 
-        enumerate_args([&](auto i, auto t)
-        {
-            auto do_computation = [&]
-            {
-                std::get<decltype(i){}>(_out) =
-                    call_ignoring_nothing(static_cast<unwrap_type<decltype(t)>&>(*this),
-                                          reinterpret_cast<Result&>(_input_buf));
+        enumerate_args(
+            [&](auto i, auto t) {
+                auto do_computation = [&] {
+                    std::get<decltype(i){}>(_out) = call_ignoring_nothing(
+                        static_cast<unwrap<decltype(t)>&>(*this),
+                        _input_buf.access());
 
-                if(_left.fetch_sub(1) == 1)
+                    if(_left.fetch_sub(1) == 1)
+                    {
+                        // TODO: make sure this destruction is correct, probably
+                        // should not destroy if storing lvalue reference
+                        _input_buf.destroy();
+                        c.execute(s, _out, cs...); // TODO: apply the tuple here
+                                                   // to pass multiple arguments
+                    }
+                };
+
+                if constexpr(i == sizeof...(Fs) - 1)
                 {
-                    // TODO: make sure this destruction is correct, probably should not destroy if storing lvalue reference
-                    reinterpret_cast<input_type&>(_input_buf).~input_type();
-                    c.execute(s, _out, cs...); // TODO: apply the tuple here to pass multiple arguments
+                    do_computation();
                 }
-            };
-
-            if constexpr(i == sizeof...(Fs) - 1)
-            {
-                do_computation();
-            }
-            else
-            {
-                // `do_computation` has to be moved here as it will die at the end of the `enumerate_args` lambda scope.
-                s([g = std::move(do_computation)]{ g(); });
-            }
-        }, type_wrapper_v<Fs>...);
+                else
+                {
+                    // `do_computation` has to be moved here as it will die at
+                    // the end of the `enumerate_args` lambda scope.
+                    s([g = std::move(do_computation)] { g(); });
+                }
+            },
+            t<Fs>...);
     }
 };
 
 template <typename ParentFwd, typename... FFwds>
-when_all(ParentFwd&&, FFwds&&...) -> when_all<std::decay_t<ParentFwd>, std::decay_t<FFwds>...>;
+when_all(ParentFwd&&, FFwds&&...)
+    ->when_all<std::decay_t<ParentFwd>, std::decay_t<FFwds>...>;
 
 template <typename... Fs>
 auto initiate(Fs&&... fs)
@@ -393,7 +354,17 @@ struct world_s_best_thread_pool
 };
 
 std::atomic<int> ctr = 0;
-struct sctr { sctr(){ ++ctr; } ~sctr(){ --ctr; } };
+struct sctr
+{
+    sctr()
+    {
+        ++ctr;
+    }
+    ~sctr()
+    {
+        --ctr;
+    }
+};
 
 void fuzzy()
 {
@@ -401,38 +372,58 @@ void fuzzy()
     std::random_device rd;
     std::default_random_engine re(rd());
 
-    const auto rndint = [&](int min, int max)
-    {
+    const auto rndint = [&](int min, int max) {
         std::scoped_lock l{mtx};
         return std::uniform_int_distribution<int>{min, max - 1}(re);
     };
 
-    const auto rndsleep = [&]
-    {
+    const auto rndsleep = [&] {
         std::this_thread::sleep_for(std::chrono::nanoseconds{rndint(0, 100)});
     };
 
     for(int i = 0; i < 1000; ++i)
     {
-        auto f = initiate([&]{ rndsleep(); return 1; },
-                          [&]{ rndsleep(); return 2; },
-                          [&]{ rndsleep(); return 3; })
-            .then([&](auto t)
-            {
+        auto f = initiate(
+            [&] {
                 rndsleep();
-                auto [a, b, c] = t;
-                assert(a + b + c == 1 + 2 + 3);
-                return 0;
-            },
-            [&](auto t)
-            {
-                rndsleep();
-                auto [a, b, c] = t;
-                assert(a + b + c == 1 + 2 + 3);
                 return 1;
-            }).then([](auto t){ auto [a, b] = t; assert(a+b==1); return std::string{"hello"}; },
-                    [](auto t){ auto [a, b] = t; assert(a+b==1); return std::string{"world"}; })
-            .then([](auto y){ auto [s0, s1] = y; assert(s0 + s1 == "helloworld"); });
+            },
+            [&] {
+                rndsleep();
+                return 2;
+            },
+            [&] {
+                rndsleep();
+                return 3;
+            })
+                     .then(
+                         [&](auto t) {
+                             rndsleep();
+                             auto [a, b, c] = t;
+                             assert(a + b + c == 1 + 2 + 3);
+                             return 0;
+                         },
+                         [&](auto t) {
+                             rndsleep();
+                             auto [a, b, c] = t;
+                             assert(a + b + c == 1 + 2 + 3);
+                             return 1;
+                         })
+                     .then(
+                         [](auto t) {
+                             auto [a, b] = t;
+                             assert(a + b == 1);
+                             return std::string{"hello"};
+                         },
+                         [](auto t) {
+                             auto [a, b] = t;
+                             assert(a + b == 1);
+                             return std::string{"world"};
+                         })
+                     .then([](auto y) {
+                         auto [s0, s1] = y;
+                         assert(s0 + s1 == "helloworld");
+                     });
 
         std::move(f).wait_and_get(world_s_best_thread_pool{});
     }
@@ -441,10 +432,10 @@ void fuzzy()
     for(int i = 0; i < 1000; ++i)
     {
         assert(ctr == 0);
-        auto f = initiate([]{ return std::make_shared<sctr>(); })
-                .then([](auto&){  assert(ctr == 1); },
-                      [](auto&){ assert(ctr == 1); })
-                .then([](auto){ assert(ctr == 0); });
+        auto f = initiate([] { return std::make_shared<sctr>(); })
+                     .then([](auto&) { assert(ctr == 1); },
+                         [](auto&) { assert(ctr == 1); })
+                     .then([](auto) { assert(ctr == 0); });
 
         std::move(f).wait_and_get(world_s_best_thread_pool{});
         assert(ctr == 0);
@@ -458,78 +449,133 @@ int main()
     fuzzy();
 
     {
-        auto f = initiate([]{ return 1; });
+        auto f = initiate([] { return 1; });
         assert(std::move(f).wait_and_get(world_s_best_thread_pool{}) == 1);
     }
 
 
     {
-        auto f = initiate([]{ return 1; })
-             .then([](int x){ return x + 1; });
+        auto f = initiate([] { return 1; }).then([](int x) { return x + 1; });
 
         assert(std::move(f).wait_and_get(world_s_best_thread_pool{}) == 2);
     }
 
     {
-        auto f = initiate([]{ return 1; })
-             .then([](int x){ return x + 1; })
-             .then([](int x){ return x + 1; });
+        auto f = initiate([] { return 1; })
+                     .then([](int x) { return x + 1; })
+                     .then([](int x) { return x + 1; });
 
         assert(std::move(f).wait_and_get(world_s_best_thread_pool{}) == 3);
     }
 
     {
-        auto f = initiate([]{ return 1; })
-                .then([](int x){ return x + 1; })
-                .then([](int){ std::cout << "void!\n"; });
+        auto f = initiate([] { return 1; })
+                     .then([](int x) { return x + 1; })
+                     .then([](int) { std::cout << "void!\n"; });
 
         std::move(f).wait_and_get(world_s_best_thread_pool{});
     }
 
     {
-        auto f = initiate([]{ return 1; }, []{ return 2; });
+        auto f = initiate([] { return 1; }, [] { return 2; });
 
-        assert(std::move(f).wait_and_get(world_s_best_thread_pool{}) == (std::tuple{1, 2}));
+        assert(std::move(f).wait_and_get(world_s_best_thread_pool{}) ==
+               (std::tuple{1, 2}));
     }
 
     {
-        auto f = initiate([]{ return 1; }, []{ return 1; })
-                .then([](auto t){ auto [a, b] = t; return a + b; });
+        auto f = initiate([] { return 1; }, [] { return 1; }).then([](auto t) {
+            auto [a, b] = t;
+            return a + b;
+        });
 
         assert(std::move(f).wait_and_get(world_s_best_thread_pool{}) == 2);
     }
 
-    auto f2 = initiate([]{ std::cout << "A0\n"; return 1; },
-                       []{ std::cout << "A1\n"; return 2; })
-       .then([](auto t)
-    {
-        auto [a, b] = t;
-        assert(a + b == 3);
-        return a + b;
-    }).then([](auto x){ assert(x == 3); std::cout << x << " C0\n"; return std::string{"hello"}; },
-            [](auto x){ assert(x == 3); std::cout << x << " C1\n"; return std::string{"world"}; })
-      .then([](auto y){ auto [s0, s1] = y; assert(s0 == "hello"); assert(s1 == "world"); std::cout << s0 << " " << s1 << "\n"; });
+    auto f2 = initiate(
+        [] {
+            std::cout << "A0\n";
+            return 1;
+        },
+        [] {
+            std::cout << "A1\n";
+            return 2;
+        })
+                  .then([](auto t) {
+                      auto [a, b] = t;
+                      assert(a + b == 3);
+                      return a + b;
+                  })
+                  .then(
+                      [](auto x) {
+                          assert(x == 3);
+                          std::cout << x << " C0\n";
+                          return std::string{"hello"};
+                      },
+                      [](auto x) {
+                          assert(x == 3);
+                          std::cout << x << " C1\n";
+                          return std::string{"world"};
+                      })
+                  .then([](auto y) {
+                      auto [s0, s1] = y;
+                      assert(s0 == "hello");
+                      assert(s1 == "world");
+                      std::cout << s0 << " " << s1 << "\n";
+                  });
 
     std::move(f2).wait_and_get(world_s_best_thread_pool{});
 
-    auto f3 = initiate([]{}).then([]{});
+    auto f3 = initiate([] {}).then([] {});
     std::move(f3).wait_and_get(world_s_best_thread_pool{});
 
-    auto f4 = initiate([]{},[]{}).then([](auto){});
+    auto f4 = initiate([] {}, [] {}).then([](auto) {});
     std::move(f4).wait_and_get(world_s_best_thread_pool{});
 
-    auto f5 = initiate([]{ std::cout << "A0\n"; return 1; },
-                       []{ std::cout << "A1\n"; return 2; })
-       .then([](auto t)
-    {
-        auto [a, b] = t;
-        assert(a + b == 3);
-        return a + b;
-    }).then([](auto x){ assert(x == 3); std::cout << x << " C0\n"; return 2; },
-            [](auto x){ assert(x == 3); std::cout << x << " C1\n"; return 3; })
-      .then([](auto t){ auto [a, b] = t; auto x = a+b; assert(x == 5); std::cout << x << " C2\n"; return 4; },
-            [](auto t){ auto [a, b] = t; auto x = a+b; assert(x == 5); std::cout << x << " C3\n"; return 5; })
-      .then([](auto y){ auto [a, b] = y; assert(a+b == 9); });
+    auto f5 = initiate(
+        [] {
+            std::cout << "A0\n";
+            return 1;
+        },
+        [] {
+            std::cout << "A1\n";
+            return 2;
+        })
+                  .then([](auto t) {
+                      auto [a, b] = t;
+                      assert(a + b == 3);
+                      return a + b;
+                  })
+                  .then(
+                      [](auto x) {
+                          assert(x == 3);
+                          std::cout << x << " C0\n";
+                          return 2;
+                      },
+                      [](auto x) {
+                          assert(x == 3);
+                          std::cout << x << " C1\n";
+                          return 3;
+                      })
+                  .then(
+                      [](auto t) {
+                          auto [a, b] = t;
+                          auto x = a + b;
+                          assert(x == 5);
+                          std::cout << x << " C2\n";
+                          return 4;
+                      },
+                      [](auto t) {
+                          auto [a, b] = t;
+                          auto x = a + b;
+                          assert(x == 5);
+                          std::cout << x << " C3\n";
+                          return 5;
+                      })
+                  .then([](auto y) {
+                      auto [a, b] = y;
+                      assert(a + b == 9);
+                  });
 
     std::move(f5).wait_and_get(world_s_best_thread_pool{});
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,7 @@ endmacro()
 foreach(_x IN LISTS vrm_cmake_out)
 #{
     target_compile_options(${_x} PUBLIC "-fdiagnostics-color=always")
+    target_link_libraries(${_x} PUBLIC "pthread")
 
     # TODO: to utility functions in vrm_cmake? to option?
     if(DEFINED AUGMENT_TESTS AND NOT DEFINED WIN_MINGW_DEVEL)

--- a/test/orizzonte/meta/constant.cpp
+++ b/test/orizzonte/meta/constant.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2017 Vittorio Romeo
+// MIT License |  https://opensource.org/licenses/MIT
+// http://vittorioromeo.info | vittorio.romeo@outlook.com
+
+#include "../../test_utils.hpp"
+#include <orizzonte/meta/constant.hpp>
+
+using namespace orizzonte::meta;
+
+template <auto X>
+struct sanity_check
+{
+    using type = decltype(X);
+};
+
+SA_SAME_TYPE(decltype(1u), unsigned int);
+
+SA_SAME_TYPE(typename sanity_check<1>::type, int);
+SA_SAME_TYPE(typename sanity_check<1l>::type, long);
+SA_SAME_TYPE(typename sanity_check<1u>::type, unsigned int);
+SA_SAME_TYPE(typename sanity_check<1ul>::type, unsigned long);
+
+SA_SAME_TYPE_DP(                     //
+    (constant_t<0>),                 //
+    (std::integral_constant<int, 0>) //
+);
+
+SA_SAME_TYPE_DP(                     //
+    (constant_t<1>),                 //
+    (std::integral_constant<int, 1>) //
+);
+
+SA_SAME_TYPE_DP(                               //
+    (constant_t<1u>),                          //
+    (std::integral_constant<unsigned int, 1u>) //
+);
+
+SA_SAME_TYPE_DP(                                 //
+    (constant_t<1ul>),                           //
+    (std::integral_constant<unsigned long, 1ul>) //
+);
+
+SA_SAME_TYPE_DP(                       //
+    (constant_t<1l>),                  //
+    (std::integral_constant<long, 1l>) //
+);
+
+SA_TYPE_IS(constant_v<0>, const constant_t<0>);
+SA_TYPE_IS(c<0>, const constant_t<0>);
+
+TEST_MAIN()
+{
+}

--- a/test/orizzonte/meta/enumerate_args.cpp
+++ b/test/orizzonte/meta/enumerate_args.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2017 Vittorio Romeo
+// MIT License |  https://opensource.org/licenses/MIT
+// http://vittorioromeo.info | vittorio.romeo@outlook.com
+
+#include "../../test_utils.hpp"
+#include <orizzonte/meta/enumerate_args.hpp>
+
+using namespace orizzonte::meta;
+
+void t0()
+{
+    enumerate_args([](auto, auto) { FAIL(); });
+}
+
+void t1()
+{
+    int acc = 0;
+    enumerate_args([&acc](auto idx, auto) { acc += idx; }, 1, 1, 1, 1);
+    EXPECT(acc == 0 + 1 + 2 + 3);
+}
+
+void t2()
+{
+    int acc = 0;
+    enumerate_args([&acc](auto, auto v) { acc += v; }, 1, 1, 1, 1);
+    EXPECT(acc == 1 + 1 + 1 + 1);
+}
+
+TEST_MAIN()
+{
+    t0();
+    t1();
+    t2();
+}

--- a/test/orizzonte/meta/sequence.cpp
+++ b/test/orizzonte/meta/sequence.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2017 Vittorio Romeo
+// MIT License |  https://opensource.org/licenses/MIT
+// http://vittorioromeo.info | vittorio.romeo@outlook.com
+
+#include "../../test_utils.hpp"
+#include <orizzonte/meta/sequence.hpp>
+
+using namespace orizzonte::meta;
+
+SA_SAME_TYPE_DP(                 //
+    (sequence_t<>),              //
+    (std::integer_sequence<int>) //
+);
+
+SA_SAME_TYPE_DP(                    //
+    (sequence_t<0>),                //
+    (std::integer_sequence<int, 0>) //
+);
+
+SA_SAME_TYPE_DP(                       //
+    (sequence_t<0, 1>),                //
+    (std::integer_sequence<int, 0, 1>) //
+);
+
+SA_SAME_TYPE_DP(                                //
+    (sequence_t<0, 1, 2, 1, 0>),                //
+    (std::integer_sequence<int, 0, 1, 2, 1, 0>) //
+);
+
+SA_SAME_TYPE_DP(                      //
+    (sequence_t<0l>),                 //
+    (std::integer_sequence<long, 0l>) //
+);
+
+SA_SAME_TYPE_DP(                                     //
+    (sequence_t<0ul, 1ul>),                          //
+    (std::integer_sequence<unsigned long, 0ul, 1ul>) //
+);
+
+SA_TYPE_IS_DP(           //
+    (sequence_v<>),      //
+    (const sequence_t<>) //
+);
+
+SA_TYPE_IS_DP(            //
+    (sequence_v<0>),      //
+    (const sequence_t<0>) //
+);
+
+SA_TYPE_IS_DP(                 //
+    (sequence_v<1l, 2l>),      //
+    (const sequence_t<1l, 2l>) //
+);
+
+TEST_MAIN()
+{
+}

--- a/test/orizzonte/utility/bool_latch.cpp
+++ b/test/orizzonte/utility/bool_latch.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2017 Vittorio Romeo
+// MIT License |  https://opensource.org/licenses/MIT
+// http://vittorioromeo.info | vittorio.romeo@outlook.com
+
+#include "../../test_utils.hpp"
+#include <chrono>
+#include <orizzonte/utility/bool_latch.hpp>
+#include <thread>
+
+using namespace orizzonte::utility;
+
+void t0()
+{
+    int i = 0;
+
+    bool_latch l;
+    std::thread t{[&] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+        i = 42;
+        l.count_down();
+    }};
+
+    l.wait();
+
+    EXPECT_EQ(i, 42);
+    t.join();
+}
+
+void t1()
+{
+    int i = 0;
+
+    std::thread t;
+    {
+        scoped_bool_latch l;
+        t = std::thread{[&] {
+            std::this_thread::sleep_for(std::chrono::milliseconds(2));
+            i = 42;
+            l.count_down();
+        }};
+    }
+
+    EXPECT_EQ(i, 42);
+    t.join();
+}
+
+TEST_MAIN()
+{
+    t0();
+    t1();
+}

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -182,7 +182,14 @@ namespace test_impl
 
 #define SA_SAME_TYPE(T0, T1) static_assert(std::is_same<T0, T1>{})
 #define SA_TYPE_IS(a, T) SA_SAME_TYPE(decltype(a), T)
+
+#define SA_TYPE_IS_DP(a, T) SA_SAME_TYPE(decltype a, TEST_IMPL_DEPARENS T)
+
 #define SA_DECAY_TYPE_IS(a, T) SA_SAME_TYPE(std::decay_t<decltype(a)>, T)
+#define SA_SAME_TYPE_DP(T0, T1) \
+    static_assert(std::is_same<TEST_IMPL_DEPARENS T0, TEST_IMPL_DEPARENS T1>{})
+
+#define FAIL() test_impl::impl::fail()
 
 struct move_only
 {


### PR DESCRIPTION
Moving some utilities from `temp.cpp` to `orizzonte`, in order to prepare for a concrete implementation 